### PR TITLE
GSO() command dumps first answer to cursor

### DIFF
--- a/plugin/gso.vim
+++ b/plugin/gso.vim
@@ -36,17 +36,20 @@ root = etree.parse(
 
 inside_pre_tag = False
 
+# Make some space if working at end of file
+vim.current.buffer.append('', current_line)
+
 for elem in root.iter():
-    known_text_tags = [
+    known_tags = [
         u'pre', u'code', u'p', u'kbd',
         u'a', u'li', u'em', u'ol', u'strong'
     ]
-    if elem.tag not in known_text_tags:
+    if elem.tag not in known_tags:
         continue
-    inline_text_tags = [
+    inline_tags = [
         u'code', u'kbd', u'a', u'em', u'strong'
     ]
-    if elem.tag not in inline_text_tags:
+    if elem.tag not in inline_tags:
         vim.current.buffer.append('', current_line+1)
         current_line += 1
 

--- a/plugin/gso.vim
+++ b/plugin/gso.vim
@@ -30,15 +30,24 @@ def wrap_with_root_tag(xml_string):
     xml_string = u"<root>"+xml_string+u"</root>"
     return xml_string
 
-root = etree.iterparse(BytesIO(wrap_with_root_tag(answers[0][1]).encode('utf-8')))
-for action, elem in root:
-    if elem.tag == u'p' or elem.tag == u'code':
-        for line in str(elem.text).split('\n'):
-            vim.current.buffer.append(line)
+parser = etree.XMLParser(recover=True)
+root = etree.parse(
+    BytesIO(wrap_with_root_tag(answers[0][1]).encode('utf-8')),
+    parser=parser)
+
+vim.current.buffer.append('')
+for elem in root.iter():
+    #if elem.tag == u'p' or elem.tag == u'code':
+    for line in str(elem.text).split('\n'):
+        if line != "None":
+            vim.current.buffer[-1] += line
+    for line in str(elem.tail).split('\n'):
+        if line != "None":
+            vim.current.buffer[-1] += (line)
 
 EOF
 
 endfunction
 
-" command! -nargs=1 GSO call GSO(question)
+command! -nargs=1 GSO call GSO(question)
 

--- a/plugin/gso.vim
+++ b/plugin/gso.vim
@@ -7,7 +7,6 @@ python << EOF
 import vim
 
 import os
-import pickle as pkl
 from io import BytesIO
 from lxml import etree
 from gso import load_up_answers, load_up_questions

--- a/plugin/gso.vim
+++ b/plugin/gso.vim
@@ -35,9 +35,8 @@ root = etree.parse(
     BytesIO(wrap_with_root_tag(answers[0][1]).encode('utf-8')),
     parser=parser)
 
-vim.current.buffer.append('')
 for elem in root.iter():
-    #if elem.tag == u'p' or elem.tag == u'code':
+    vim.current.buffer.append('')
     for line in str(elem.text).split('\n'):
         if line != "None":
             vim.current.buffer[-1] += line

--- a/plugin/gso.vim
+++ b/plugin/gso.vim
@@ -35,14 +35,22 @@ root = etree.parse(
     BytesIO(wrap_with_root_tag(answers[0][1]).encode('utf-8')),
     parser=parser)
 
+inside_pre_tag = False
+
 for elem in root.iter():
     vim.current.buffer.append('')
+    if elem.tag == u'pre':
+        inside_pre_tag = True
     for line in str(elem.text).split('\n'):
         if line != "None":
             vim.current.buffer[-1] += line
+	    if elem.tag == u'code' and inside_pre_tag == True:
+                vim.current.buffer.append('')
     for line in str(elem.tail).split('\n'):
         if line != "None":
             vim.current.buffer[-1] += (line)
+    if elem.tag == u'code' and inside_pre_tag == True:
+        inside_pre_tag = False
 
 EOF
 

--- a/plugin/gso.vim
+++ b/plugin/gso.vim
@@ -1,6 +1,6 @@
-function! GSO(question)
+function! GSO(...)
 
-let firstarg=a:question
+let all_args=a:000
 
 python << EOF
 
@@ -10,7 +10,7 @@ from io import BytesIO
 from lxml import etree
 from gso import load_up_answers, load_up_questions
 
-question = vim.eval("firstarg")
+question = " ".join([str(word) for word in vim.eval("all_args")])
 starting_line = vim.current.window.cursor[0]
 current_line = starting_line
 
@@ -66,11 +66,7 @@ for elem in root.iter():
 
 EOF
 
-
-
 endfunction
 
-
-
-command! -nargs=1 GSO call GSO(<f-args>)
+command! -nargs=* GSO call GSO(<f-args>)
 


### PR DESCRIPTION
- Fixes GSO() command usage so it doesn't need explicit quotations around the question
- Dumps to current cursor position, not end of file
- Only puts newlines where they need to be, not at each new HTML tag
- Works with more possible SO tags

You can now call:

```vim
:GSO Set tab to be 4 spaces in vim
```
and gso will dump below your cursor the following output (which turns out to be from [here](https://stackoverflow.com/a/234578/2689923):

``` vim
As has been pointed out in a couple of answers below, the preferred method now is NOT to use smartindent, but instead use the following (in your .vimrc):
filetype plugin indent on
" show existing tab with 4 spaces width
set tabstop=4
" when indenting with '>', use 4 spaces width
set shiftwidth=4
" On pressing tab, insert 4 spaces
set expandtab


.vimrc: file:
set smartindent
set tabstop=4
set shiftwidth=4
set expandtab


The help files take a bit of time to get used to, but the more you read, the better Vim gets:
:help smartindent


Even better, you can embed these settings in your source for portability:
:help auto-setting


To see your current settings:
:set all


As graywh points out in the comments, smartindent has been replaced by cindent which "Works more cleverly", although still mainly for languages with C-like syntax:
:help C-indenting
```
You can then delete the textual bits. 