### PR TITLE
Single-line comments

### DIFF
--- a/plugin/gso.vim
+++ b/plugin/gso.vim
@@ -127,7 +127,7 @@ for elem in root.iter():
         if curr_lang in comments and not block_comments_enabled:
             """Do a single line comment"""
             vim.current.buffer.append(comments[curr_lang], current_line+1)
-        else
+        else:
             vim.current.buffer.append('', current_line+1)
         current_line += 1
 
@@ -144,7 +144,7 @@ for elem in root.iter():
         inside_pre_tag = False
 
 if inside_comment == True:
-    if block_comments_enabled
+    if block_comments_enabled:
         vim.current.buffer.append(
             comments[curr_lang][1], current_line+1)
         current_line += 1

--- a/plugin/gso.vim
+++ b/plugin/gso.vim
@@ -23,6 +23,8 @@ from io import BytesIO
 from lxml import etree
 from gso import load_up_answers, load_up_questions
 
+# ["___", "____"] - interpreted as block comment
+# "___" - interpreted as single-line comment
 comments = {
     'python': ["\"\"\"", "\"\"\""],
     'haskell': ["{-", "-}"],
@@ -36,6 +38,7 @@ comments = {
     'perl': ["=begin", "=cut"],
     'tex': "%",
     'plaintex': "%",
+    'latex': "%",
     'html': ["<!--", "-->"]
 }
 


### PR DESCRIPTION
This PR adds support for single-line comments of text in SO answers. This is to be used only when there do not exist block comments for the language (e.g., latex).