### PR TITLE
Add start/end markers for GSO output

### DIFF
--- a/plugin/gso.vim
+++ b/plugin/gso.vim
@@ -111,6 +111,7 @@ elif curr_lang in comments:
 else:
     vim.current.buffer.append(
         "GSO>>>", current_line+1)
+vim.current.buffer.append('', current_line+1)
 current_line += 1
 
 for elem in root.iter():

--- a/plugin/gso.vim
+++ b/plugin/gso.vim
@@ -96,23 +96,18 @@ block_comments_enabled = False
 if curr_lang in comments and len(comments[curr_lang]) == 2:
     block_comments_enabled = True
 
-# Make some space if working at end of file
-vim.current.buffer.append('', current_line)
-
 #Mark the start of input
 if block_comments_enabled:
     vim.current.buffer.append(
         comments[curr_lang][0]+"GSO>>>"+comments[curr_lang][1],
-        current_line+1)
+        current_line)
 elif curr_lang in comments:
     vim.current.buffer.append(
         comments[curr_lang]+"GSO>>>",
-        current_line+1)
+        current_line)
 else:
     vim.current.buffer.append(
-        "GSO>>>", current_line+1)
-vim.current.buffer.append('', current_line+1)
-current_line += 2
+        "GSO>>>", current_line)
 
 for elem in root.iter():
     known_tags = [

--- a/plugin/gso.vim
+++ b/plugin/gso.vim
@@ -99,6 +99,19 @@ if curr_lang in comments and len(comments[curr_lang]) == 2:
 # Make some space if working at end of file
 vim.current.buffer.append('', current_line)
 
+#Mark the start of input
+if block_comments_enabled:
+    vim.current.buffer.append(
+        comments[curr_lang][0]+"GSO>>>"+comments[curr_lang][1],
+        current_line+1)
+elif curr_lang in comments:
+    vim.current.buffer.append(
+        comments[curr_lang]+"GSO>>>",
+        current_line+1)
+else:
+    vim.current.buffer.append(
+        "GSO>>>", current_line+1)
+
 for elem in root.iter():
     known_tags = [
         u'pre', u'code', u'p', u'kbd',
@@ -151,6 +164,19 @@ if inside_comment == True:
             comments[curr_lang][1], current_line+1)
         current_line += 1
         inside_comment = False
+
+#Mark the end of input
+if block_comments_enabled:
+    vim.current.buffer.append(
+        comments[curr_lang][0]+"<<<GSO"+comments[curr_lang][1],
+        current_line+1)
+elif curr_lang in comments:
+    vim.current.buffer.append(
+        comments[curr_lang]+"<<<GSO",
+        current_line+1)
+else:
+    vim.current.buffer.append(
+        "<<<GSO", current_line+1)
 
 EOF
 

--- a/plugin/gso.vim
+++ b/plugin/gso.vim
@@ -112,7 +112,7 @@ else:
     vim.current.buffer.append(
         "GSO>>>", current_line+1)
 vim.current.buffer.append('', current_line+1)
-current_line += 1
+current_line += 2
 
 for elem in root.iter():
     known_tags = [

--- a/plugin/gso.vim
+++ b/plugin/gso.vim
@@ -111,6 +111,7 @@ elif curr_lang in comments:
 else:
     vim.current.buffer.append(
         "GSO>>>", current_line+1)
+current_line += 1
 
 for elem in root.iter():
     known_tags = [


### PR DESCRIPTION
This PR adds markers for the GSO output:

- `GSO>>>` - precedes the output
- `<<<GSO` - follows the output

Both of these are put into comments on new lines.

This is useful so you can quickly grab the code you want, and then "d/GSO" \*enter\* to delete the rest of it