### PR TITLE
New flag for not printing answer text

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ And watch the code get dumped below your cursor.
 GSO will append the language to your query by the file extension, but you can set it explicitly by:
 
 ````
-:GSO --lang=haskell Generate a fibonacci sequence
+:GSO -l haskell Generate a fibonacci sequence
 ````
 
 Docker

--- a/README.md
+++ b/README.md
@@ -75,3 +75,5 @@ And it will dump the highest score answer to below your cursor.
 -   StackAnswers.vim - <https://github.com/james9909/stackanswers.vim>
     -   Almost what I want, but it doesn't paste answers into the buffer
         automatically, and I can't seem to get it working on my Mac.
+    -   Does not use the official Google API, which puts your IP address
+        at risk of being [blocked by Google](https://stackoverflow.com/questions/22657548/is-it-ok-to-scrape-data-from-google-results).

--- a/README.md
+++ b/README.md
@@ -35,13 +35,18 @@ Then, just `:PluginInstall` in vim.
 Usage
 -----
 
-Inside vim, run:
+````
+:GSO [(-l | --language) <language>] [-n | --no-text] [<search>...]
+````
+
+
+For example, in a file `sort.py`, run:
 
 ````
 :GSO Do a bubble sort
 ````
 
-And watch the code get dumped below your cursor.
+And watch the python code get dumped below your cursor.
 GSO will append the language to your query by the file extension, but you can set it explicitly by:
 
 ````

--- a/doc/gso.txt
+++ b/doc/gso.txt
@@ -13,7 +13,7 @@ These commands are local to the buffers in which they are called.
 
 SYNOPSIS
 
-:GSO [(-l | --lang) <language>] [-n | --no-text] [<search>...]
+:GSO [(-l | --language) <language>] [-n | --no-text] [<search>...]
 
 DESCRIPTION
 
@@ -24,7 +24,7 @@ DESCRIPTION
                             text format. The following [flags] are 
                             available:
 
-                            -l <language>, --lang <language>
+                            -l <language>, --language <language>
 
                                 Set the programming language for the
                                 search, if it is different than the

--- a/doc/gso.txt
+++ b/doc/gso.txt
@@ -10,14 +10,21 @@ These commands are local to the buffers in which they are called.
 
 
                                                                 *:GSO*
-:GSO [flags] [search]       Search Google with the query [search], find
+
+SYNOPSIS
+
+:GSO [(-l | --lang) <language>] [-n | --no-text] [<search>...]
+
+DESCRIPTION
+
+                            Search Google with the query [search], find
                             the first relevant Stack Exchange result,
                             then dump the answer with the highest score
                             to the line below the cursor, in plain
                             text format. The following [flags] are 
                             available:
 
-                            --lang=[language]
+                            -l <language>, --lang <language>
 
                                 Set the programming language for the
                                 search, if it is different than the
@@ -26,6 +33,11 @@ These commands are local to the buffers in which they are called.
                                 Note that some languages (e.g., C++)
                                 are mapped from a different code (for
                                 C++, it is from cpp)
+
+                            -n , --no-text
+
+                                Don't paste any of the answer text,
+                                just the code.
 
 ==========================================================================
 About                                                          *gso-about*

--- a/doc/gso.txt
+++ b/doc/gso.txt
@@ -22,7 +22,10 @@ These commands are local to the buffers in which they are called.
                                 Set the programming language for the
                                 search, if it is different than the
                                 current syntax highlighting language.
-                                You can check this with (:echo &ft)
+                                You can check this with (:echo &ft).
+                                Note that some languages (e.g., C++)
+                                are mapped from a different code (for
+                                C++, it is from cpp)
 
 ==========================================================================
 About                                                          *gso-about*

--- a/plugin/gso.vim
+++ b/plugin/gso.vim
@@ -80,7 +80,7 @@ try:
     gso_command = vars(parser.parse_args(all_args))
 except SystemExit:
     print "Exiting GSO"
-    exit()
+    EOF
 
 curr_lang = gso_command['lang']
 no_text = gso_command['no_text']

--- a/plugin/gso.vim
+++ b/plugin/gso.vim
@@ -76,7 +76,7 @@ parser.add_argument('search', nargs='+')
 gso_command = vars(parser.parse_args(all_args))
 
 curr_lang = gso_command['lang']
-no_text = gso_command['no-text']
+no_text = gso_command['no_text']
 question = gso_command['search']
 
 """Now all the options are loaded"""

--- a/plugin/gso.vim
+++ b/plugin/gso.vim
@@ -69,7 +69,7 @@ no_text = False
 parser = argparse.ArgumentParser(description="Process a search query")
 
 parser.add_argument('-l', '--lang', default=curr_lang)
-parser.add_argument('-n', '--no-text', action='store_true')
+parser.add_argument('-n', '--no-text', action='store_true', default=False)
 parser.add_argument('search', nargs='+')
 
 """Parse!"""

--- a/plugin/gso.vim
+++ b/plugin/gso.vim
@@ -69,7 +69,7 @@ no_text = False
 parser = argparse.ArgumentParser(description="Process a search query")
 
 parser.add_argument(
-    '-l', '--lang', default=curr_lang, help="Set the language explicitly")
+    '-l', '--language', default=curr_lang, help="Set the language explicitly")
 parser.add_argument(
     '-n', '--no-text', action='store_true', default=False,
     help="Don't print the answer text")
@@ -78,7 +78,7 @@ parser.add_argument('search', nargs='+', help="The search keywords")
 """Parse!"""
 gso_command = vars(parser.parse_args(all_args))
 
-curr_lang = gso_command['lang']
+curr_lang = gso_command['language']
 no_text = gso_command['no_text']
 question = gso_command['search']
 

--- a/plugin/gso.vim
+++ b/plugin/gso.vim
@@ -19,6 +19,7 @@ python << EOF
 
 import vim
 import os
+import argparse
 from io import BytesIO
 from lxml import etree
 from gso import load_up_answers, load_up_questions
@@ -50,25 +51,35 @@ search_mapping = {
 }
 
 
-
+"""Load up options"""
 
 all_args = vim.eval("all_args")
 
-"""Load up what language to scrape code from"""
-lang_flag = "--lang="
+"""Get default language"""
+curr_lang = ""
+try:
+    curr_lang = vim.current.buffer.vars['current_syntax']
+except:
+    pass
 
-if len(all_args[0]) >= len(lang_flag) and \
-        all_args[0][:len(lang_flag)] == lang_flag:
+"""Text turned on?"""
+no_text = False
 
-    curr_lang = all_args[0][len(lang_flag):]
-    question = " ".join([str(word) for word in all_args[1:]])
-else:
-    curr_lang = ""
-    try:
-        curr_lang = vim.current.buffer.vars['current_syntax']
-    except:
-        pass
-    question = " ".join([str(word) for word in all_args])
+"""Create parser for args"""
+parser = argparse.ArgumentParser(description="Process a search query")
+
+parser.add_argument('-l', '--lang', default=curr_lang)
+parser.add_argument('-n', '--no-text', action='store_true')
+parser.add_argument('search', nargs='+')
+
+"""Parse!"""
+gso_command = vars(parser.parse_args(all_args))
+
+curr_lang = gso_command['lang']
+no_text = gso_command['no-text']
+question = gso_command['search']
+
+"""Now all the options are loaded"""
 
 starting_line = vim.current.window.cursor[0]
 current_line = starting_line

--- a/plugin/gso.vim
+++ b/plugin/gso.vim
@@ -42,6 +42,13 @@ comments = {
     'html': ["<!--", "-->"]
 }
 
+# Some filetypes from vim 
+# should be searched with a different
+# name.
+search_mapping = {
+    'cpp': 'C++'
+}
+
 
 
 
@@ -68,7 +75,13 @@ current_line = starting_line
 
 results = []
 i = 0
-for result in load_up_questions(str(question), curr_lang):
+
+# Should we search it with a different name?
+search_lang = curr_lang
+if curr_lang in search_mapping:
+    search_lang = search_mapping[curr_lang]
+
+for result in load_up_questions(str(question), search_lang):
     results.append(result)
     i += 1
     if i > 1:

--- a/plugin/gso.vim
+++ b/plugin/gso.vim
@@ -76,11 +76,7 @@ parser.add_argument(
 parser.add_argument('search', nargs='+', help="The search keywords")
 
 """Parse!"""
-try:
-    gso_command = vars(parser.parse_args(all_args))
-except SystemExit:
-    print "Exiting GSO"
-    EOF
+gso_command = vars(parser.parse_args(all_args))
 
 curr_lang = gso_command['lang']
 no_text = gso_command['no_text']

--- a/plugin/gso.vim
+++ b/plugin/gso.vim
@@ -146,6 +146,10 @@ for elem in root.iter():
 
     if elem.tag == u'pre':
         inside_pre_tag = True
+    elif not inside_pre_tag and no_text:
+        """No printing out text of answer"""
+        continue
+
     if inside_comment == False and inside_pre_tag == False:
         """Do some block commenting"""
         if block_comments_enabled:

--- a/plugin/gso.vim
+++ b/plugin/gso.vim
@@ -68,12 +68,19 @@ no_text = False
 """Create parser for args"""
 parser = argparse.ArgumentParser(description="Process a search query")
 
-parser.add_argument('-l', '--lang', default=curr_lang)
-parser.add_argument('-n', '--no-text', action='store_true', default=False)
-parser.add_argument('search', nargs='+')
+parser.add_argument(
+    '-l', '--lang', default=curr_lang, help="Set the language explicitly")
+parser.add_argument(
+    '-n', '--no-text', action='store_true', default=False,
+    help="Don't print the answer text")
+parser.add_argument('search', nargs='+', help="The search keywords")
 
 """Parse!"""
-gso_command = vars(parser.parse_args(all_args))
+try:
+    gso_command = vars(parser.parse_args(all_args))
+except SystemExit:
+    print "Exiting GSO"
+    exit()
 
 curr_lang = gso_command['lang']
 no_text = gso_command['no_text']


### PR DESCRIPTION
- Flag for no answer text
- Now using python argparse for more robust flag abilities
- Make docs better and updated them to this flag

When you just want code without words, this is the flag to do it: "-n" or "--no-text". The "GSO>>>", "<<<GSO" comments will still surround the pasted code.