### PR TITLE
Add option for no language

### DIFF
--- a/doc/gso.txt
+++ b/doc/gso.txt
@@ -9,7 +9,7 @@ Commands                                                    *gso-commands*
 These commands are local to the buffers in which they are called.
 
 
-                                                  *gso* *GSO* *:GSO*
+                                                        *GSO* *:GSO*
 
 SYNOPSIS
 

--- a/doc/gso.txt
+++ b/doc/gso.txt
@@ -34,6 +34,10 @@ DESCRIPTION
                                 are mapped from a different code (for
                                 C++, it is from cpp)
 
+                                Set <language> to be 'none', 'nothing',
+                                or 'no' for nothing to be appended to
+                                your search query.
+
                             -n , --no-text
 
                                 Don't paste any of the answer text,

--- a/doc/gso.txt
+++ b/doc/gso.txt
@@ -9,7 +9,7 @@ Commands                                                    *gso-commands*
 These commands are local to the buffers in which they are called.
 
 
-                                                                *:GSO*
+                                                  *gso* *GSO* *:GSO*
 
 SYNOPSIS
 
@@ -35,8 +35,8 @@ DESCRIPTION
                                 C++, it is from cpp)
 
                                 Set <language> to be 'none', 'nothing',
-                                or 'no' for nothing to be appended to
-                                your search query.
+                                or 'no' for no language to be appended
+                                to your search query.
 
                             -n , --no-text
 

--- a/plugin/gso.vim
+++ b/plugin/gso.vim
@@ -95,10 +95,13 @@ current_line = starting_line
 results = []
 i = 0
 
+no_language_setting = ['none', 'nothing', 'no']
 # Should we search it with a different name?
 search_lang = curr_lang
 if curr_lang in search_mapping:
     search_lang = search_mapping[curr_lang]
+elif curr_lang.lower() in no_language_setting:
+    search_lang = ""
 
 for result in load_up_questions(str(question), search_lang):
     results.append(result)


### PR DESCRIPTION
By calling:
```
:GSO -l no My search query
```
Even if you are inside a file with a known syntax, GSO will not append anything to your search and will not wrap answer text with language-specific comments.

`-l nothing` and `-l none` also work.